### PR TITLE
fix: Change page wrapper scroll to auto

### DIFF
--- a/pages/[tweet].js
+++ b/pages/[tweet].js
@@ -68,7 +68,7 @@ export default function Tweet({ date, ast }) {
           color: var(--tweet-font-color);
           background: var(--bg-color);
           height: 100vh;
-          overflow: scroll;
+          overflow: auto;
           padding: 2rem 1rem;
         }
         main {

--- a/pages/t/[tweet].js
+++ b/pages/t/[tweet].js
@@ -68,7 +68,7 @@ export default function Tweet({ date, ast }) {
           color: var(--tweet-font-color);
           background: var(--bg-color);
           height: 100vh;
-          overflow: scroll;
+          overflow: auto;
           padding: 2rem 1rem;
         }
         main {


### PR DESCRIPTION
Stops white bars at side/bottom of the page that are placeholders for the scroll bars, when the content currently fits the viewport fine with no scrolling.

#### Current

(White bar at right side and bottom of screen, hard to see due to white background of GitHub)

![Screenshot 2020-05-29 at 15 05 11](https://user-images.githubusercontent.com/5610674/83268859-2122ac00-a1be-11ea-9c26-879a26cbdf79.png)

#### With `auto` and small viewport

![Screenshot 2020-05-29 at 15 04 48](https://user-images.githubusercontent.com/5610674/83268905-31d32200-a1be-11ea-93d4-d6d3e0aa729a.png)

#### With `auto` and large viewport

![Screenshot 2020-05-29 at 15 04 57](https://user-images.githubusercontent.com/5610674/83268914-3697d600-a1be-11ea-907f-367454bb7d9e.png)
