### PR TITLE
Handle refresh if client has js disabled

### DIFF
--- a/pages/[tweet].js
+++ b/pages/[tweet].js
@@ -47,7 +47,16 @@ export default function Tweet({ date, ast }) {
       <TweetMeta />
 
       <main>
-        {isFallback ? <TweetSkeleton /> : <Node components={components} node={ast[0]} />}
+        {isFallback ? 
+          <>
+            <TweetSkeleton />
+            <noscript>
+              <meta httpEquiv="refresh" content="5" />
+            </noscript>
+          </>
+          : 
+          <Node components={components} node={ast[0]} />
+        }
 
         <footer>
           <p>


### PR DESCRIPTION
We wanted to use this static generation method to serve a page for each timezone for f1calendar.com. These are used for users with js disabled, while rare we want this site to be as accessible as possible.

This refresh allows any non-generated timezone page to be generated and served once generated. We're then able to keep the number of pages being deployed down to a minimum and below the limits of Vercel.

Perhaps there is a better way to do this. :) 